### PR TITLE
Disable custom channels when in ghost mode

### DIFF
--- a/src/main/java/dog/kaylen/rebrand/mixins/ClientBrandRetrieverMixin.java
+++ b/src/main/java/dog/kaylen/rebrand/mixins/ClientBrandRetrieverMixin.java
@@ -7,8 +7,6 @@ package dog.kaylen.rebrand.mixins;
 import dog.kaylen.rebrand.RebrandClientMod;
 import dog.kaylen.rebrand.config.RebrandModConfig;
 import net.minecraft.client.ClientBrandRetriever;
-import net.minecraft.network.packet.c2s.login.LoginQueryResponseC2SPacket;
-import net.minecraft.network.packet.s2c.login.LoginQueryRequestS2CPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -20,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(ClientBrandRetriever.class)
 public class ClientBrandRetrieverMixin {
 	@Inject(at = @At("HEAD"), method = "getClientModName", cancellable = true, remap = false)
-	private static void getConfiguredClientBrand(CallbackInfoReturnable<String> info) {
+	private static void rebrand$getConfiguredClientBrand(CallbackInfoReturnable<String> info) {
 		// prevent npe on client initialization
 		if (RebrandClientMod.getInstance() == null) {
 			info.setReturnValue("fabric");
@@ -33,5 +31,4 @@ public class ClientBrandRetrieverMixin {
 		}
 		info.setReturnValue(config.brandName);
 	}
-
 }

--- a/src/main/java/dog/kaylen/rebrand/mixins/ClientConnectionMixin.java
+++ b/src/main/java/dog/kaylen/rebrand/mixins/ClientConnectionMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Kaylen Dart 2022
+ * This project is licensed under the GNU GPLv3 license. See the LICENSE file for more information.
+ */
+package dog.kaylen.rebrand.mixins;
+
+import dog.kaylen.rebrand.RebrandClientMod;
+import dog.kaylen.rebrand.config.RebrandModConfig;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.PacketCallbacks;
+import net.minecraft.network.packet.Packet;
+import net.minecraft.network.packet.c2s.common.CustomPayloadC2SPacket;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Prevents the client from sending custom payload packets ( except vanilla ones that aren't (un)register ) when ghost mode is enabled.
+ */
+@Mixin(ClientConnection.class)
+public class ClientConnectionMixin {
+	@Inject(method = "send(Lnet/minecraft/network/packet/Packet;Lnet/minecraft/network/PacketCallbacks;Z)V", at = @At("HEAD"), cancellable = true)
+	public void rebrand$send(Packet<?> packet, @Nullable PacketCallbacks callbacks, boolean flush, CallbackInfo ci) {
+		// default to ghost mode if the mod is not initialized - shouldn't occur!
+		if (RebrandClientMod.getInstance() == null) {
+			ci.cancel();
+		}
+		RebrandModConfig config = RebrandClientMod.getInstance().getConfig();
+		if (!config.enable || !config.ghostMode) {
+			return;
+		}
+		if (!(packet instanceof CustomPayloadC2SPacket)) {
+			return;
+		}
+		if (((CustomPayloadC2SPacket) packet).payload().id().toString().matches("minecraft:(?!(?:un)?register).*")) {
+			return;
+		}
+		ci.cancel();
+	}
+}

--- a/src/main/java/dog/kaylen/rebrand/mixins/LoginQueryResponseC2SPacketMixin.java
+++ b/src/main/java/dog/kaylen/rebrand/mixins/LoginQueryResponseC2SPacketMixin.java
@@ -14,10 +14,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+/**
+ * Prevents the client from sending a response to the server when ghost mode is enabled.
+ */
 @Mixin(LoginQueryResponseC2SPacket.class)
 public class LoginQueryResponseC2SPacketMixin {
 	@Inject(at = @At("TAIL"), method = "response()Lnet/minecraft/network/packet/c2s/login/LoginQueryResponsePayload;")
-	private void response(CallbackInfoReturnable<LoginQueryResponsePayload> info) {
+	private void rebrand$response(CallbackInfoReturnable<LoginQueryResponsePayload> info) {
 		// default to ghost mode if the mod is not initialized - shouldn't occur!
 		if (RebrandClientMod.getInstance() == null) {
 			info.setReturnValue(null);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,8 @@
         "RazrCraft",
         "Calvineries",
         "iffyspeak-chroma",
-        "Nukecraft5419"
+        "Nukecraft5419",
+        "Julienraptor01"
     ],
     "contact": {
         "homepage": "https://www.curseforge.com/minecraft/mc-mods/rebrand",

--- a/src/main/resources/rebrand.mixins.json
+++ b/src/main/resources/rebrand.mixins.json
@@ -5,8 +5,9 @@
     "compatibilityLevel": "JAVA_17",
     "mixins": [],
     "client": [
-      "ClientBrandRetrieverMixin",
-      "LoginQueryResponseC2SPacketMixin"
+        "ClientBrandRetrieverMixin",
+        "ClientConnectionMixin",
+        "LoginQueryResponseC2SPacketMixin"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
- Add a `ClientConnection` mixin to prevent `CustomPayloadC2SPacket`s from making it out of the client
- Add the mod id in front of injected methods

Fixes #20 