### PR TITLE
Allow versions greater than 1.20.2 to work

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,7 @@
     ],
     "depends": {
         "fabricloader": ">=0.14",
-        "minecraft": "1.20.2",
+        "minecraft": "^1.20.2",
         "java": ">=17"
     },
     "suggests": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,7 @@
     ],
     "depends": {
         "fabricloader": ">=0.14",
-        "minecraft": "^1.20.2",
+        "minecraft": ">=1.20.2",
         "java": ">=17"
     },
     "suggests": {


### PR DESCRIPTION
Probably the simplest pull request I have done. 😂 

As I personally tested, this mod works with all minor versions of Minecraft 1.20. Currently, `fabric-mod.json` only permits using this mod under Minecraft 1.20.2. This PR fixes it by modifying `fabric-mod.json` with a selector which allows for all minor versions of Minecraft 1.20 to load this mod under Fabric Loader.